### PR TITLE
Dn/traverse fields constants+model visitor

### DIFF
--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TsModelBuilder.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TsModelBuilder.cs
@@ -148,8 +148,8 @@ namespace TypeLite {
         /// <returns>The script model with the classes.</returns>
         public TsModel Build() {
             var model = new TsModel(this.Classes.Values, this.Enums.Values);
-            if (_modelVisitor != null) model.RunVisitor(_modelVisitor);
             model.RunVisitor(new TypeResolver(model));
+            if (_modelVisitor != null) model.RunVisitor(_modelVisitor);
             return model;
         }
 
@@ -223,6 +223,24 @@ namespace TypeLite {
         public void RegisterModelVisitor(ITsModelVisitor modelVisitor)
         {
             _modelVisitor = modelVisitor;
+        }
+
+        public bool ContainsType(Type clrType)
+        {
+            return GetType(clrType) != null;
+        }
+
+        public TsType GetType(Type clrType)
+        {
+            TsClass tsClass = null;
+            if (Classes.TryGetValue(clrType, out tsClass))
+                return tsClass;
+
+            TsEnum tsEnum = null;
+            if (Enums.TryGetValue(clrType, out tsEnum))
+                return tsEnum;
+
+            return null;
         }
     }
 

--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TsModelBuilder.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TsModelBuilder.cs
@@ -12,6 +12,8 @@ namespace TypeLite {
     /// Creates a script model from CLR classes.
     /// </summary>
     public class TsModelBuilder {
+        private ITsModelVisitor _modelVisitor;
+
         /// <summary>
         /// Gets or sets collection of classes in the model being built.
         /// </summary>
@@ -146,6 +148,7 @@ namespace TypeLite {
         /// <returns>The script model with the classes.</returns>
         public TsModel Build() {
             var model = new TsModel(this.Classes.Values, this.Enums.Values);
+            if (_modelVisitor != null) model.RunVisitor(_modelVisitor);
             model.RunVisitor(new TypeResolver(model));
             return model;
         }
@@ -211,6 +214,15 @@ namespace TypeLite {
                     this.Add(genericArgument.Type);
                 }
             }
+        }
+
+        /// <summary>
+        /// Registers a model visitor which will trigger for each entity added to the model
+        /// </summary>
+        /// <param name="modelVisitor"></param>
+        public void RegisterModelVisitor(ITsModelVisitor modelVisitor)
+        {
+            _modelVisitor = modelVisitor;
         }
     }
 

--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TsModelBuilder.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TsModelBuilder.cs
@@ -155,7 +155,7 @@ namespace TypeLite {
         /// </summary>
         /// <param name="classModel"></param>
         private void AddReferences(TsClass classModel, Dictionary<Type, TypeConvertor> typeConvertors) {
-            foreach (var property in classModel.Properties.Where(model => !model.IsIgnored)) {
+            foreach (var property in classModel.Properties.Concat(classModel.Fields).Concat(classModel.Constants).Where(model => !model.IsIgnored)) {
                 var propertyTypeFamily = TsType.GetTypeFamily(property.PropertyType.Type);
                 if (propertyTypeFamily == TsTypeFamily.Collection) {
                     var collectionItemType = TsType.GetEnumerableType(property.PropertyType.Type);

--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TypeScript.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TypeScript.cs
@@ -256,12 +256,22 @@ namespace TypeLite {
 			return this;
 		}
 
-		/// <summary>
-		/// Registers a typescript reference file
-		/// </summary>
-		/// <param name="reference">Name of the d.ts typescript reference file</param>
-		/// <returns></returns>
-		public TypeScriptFluent WithReference(string reference) {
+        /// <summary>
+        /// Registers a model visitor which will trigger for each entity added to the model
+        /// </summary>
+        /// <param name="modelVisitor"></param>
+	    public TypeScriptFluent WithModelVisitor(ITsModelVisitor modelVisitor)
+	    {
+	        _modelBuilder.RegisterModelVisitor(modelVisitor);
+	        return this;
+        }
+
+        /// <summary>
+        /// Registers a typescript reference file
+        /// </summary>
+        /// <param name="reference">Name of the d.ts typescript reference file</param>
+        /// <returns></returns>
+        public TypeScriptFluent WithReference(string reference) {
 			_scriptGenerator.AddReference(reference);
 			return this;
 		}
@@ -312,6 +322,7 @@ namespace TypeLite {
 		public override string ToString() {
 			return this.Generate();
 		}
+
 	}
 
 	/// <summary>

--- a/TypeGap/TypeConverter.cs
+++ b/TypeGap/TypeConverter.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using TypeLite;
+using TypeLite.TsModels;
 
 namespace TypeGap
 {
@@ -57,7 +58,14 @@ namespace TypeGap
         {
             if (clrType == null)
                 System.Diagnostics.Debugger.Break();
-            return String.IsNullOrEmpty(_globalNamespace) ? clrType.FullName : _globalNamespace + "." + clrType.Name;
+
+            string moduleName = null;
+
+            var tsMember = _fluent.ModelBuilder.GetType(clrType) as TsModuleMember;
+            if (tsMember != null)
+                moduleName = tsMember.Module.Name + "." + tsMember.Name;
+
+            return String.IsNullOrEmpty(_globalNamespace) ? (moduleName ?? clrType.FullName) : _globalNamespace + "." + clrType.Name;
         }
 
         public string GetTypeScriptName(Type clrType)

--- a/TypeGap/TypeFluent.cs
+++ b/TypeGap/TypeFluent.cs
@@ -32,6 +32,7 @@ namespace TypeGap
         private bool _generateNotice = true;
         private GapEnumGenerator _enumGenerator = new RegularEnumGenerator(false, EnumValueMode.Number);
         private string _indent = "    ";
+        private ITsModelVisitor _modelVisitor;
 
         public TypeFluent Add(Type t)
         {
@@ -91,6 +92,7 @@ namespace TypeGap
             TypeScriptFluent fluent = new TypeScriptFluent();
             fluent.WithConvertor<Guid>(c => "string");
             fluent.WithIndentation(_indent);
+            fluent.WithModelVisitor(_modelVisitor);
 
             var converter = new TypeConverter(_namespace, fluent);
             fluent.WithDictionaryMemberFormatter(converter);
@@ -160,6 +162,12 @@ namespace TypeGap
         public TypeFluent WithEnumGenerator(GapEnumGenerator generator)
         {
             _enumGenerator = generator;
+            return this;
+        }
+
+        public TypeFluent WithModelVisitor(ITsModelVisitor visitor)
+        {
+            _modelVisitor = visitor;
             return this;
         }
 


### PR DESCRIPTION
1. This will traverse not only properties of TsClass, but also fields & constants when discovering referenced types.
2. Also allows to register custom implementation IModelVisitor on top of the default, which makes possible to override model (change namespaces, visibility of classes and their internals etc.).
3. Fixes stack overflow when manually adding types referring to themselves.
4. CLR Type full names is generated from related TsType module name, if such is found in model builder.