### PR TITLE
Fix exception on multiple identical generics

### DIFF
--- a/TypeGap/TypeConverter.cs
+++ b/TypeGap/TypeConverter.cs
@@ -135,12 +135,11 @@ namespace TypeGap
 
             if (clrType.GetDnxCompatible().IsClass || clrType.GetDnxCompatible().IsInterface)
             {
+                _fluent.ModelBuilder.Add(clrType);
+
                 var name = GetFullName(clrType);
                 if (clrType.GetDnxCompatible().IsGenericType)
                 {
-                    var indexOfBacktick = name.IndexOf('`');
-                    if (indexOfBacktick > 0) name = name.Remove(indexOfBacktick);
-
                     name += "<";
                     var count = 0;
                     foreach (var genericArgument in clrType.GetDnxCompatible().GetGenericArguments())
@@ -150,7 +149,6 @@ namespace TypeGap
                     }
                     name += ">";
                 }
-                _fluent.ModelBuilder.Add(clrType);
                 return name;
             }
 

--- a/TypeGap/TypeConverter.cs
+++ b/TypeGap/TypeConverter.cs
@@ -138,7 +138,10 @@ namespace TypeGap
                 var name = GetFullName(clrType);
                 if (clrType.GetDnxCompatible().IsGenericType)
                 {
-                    name = GetFullName(clrType).Remove(GetFullName(clrType).IndexOf('`')) + "<";
+                    var indexOfBacktick = name.IndexOf('`');
+                    if (indexOfBacktick > 0) name = name.Remove(indexOfBacktick);
+
+                    name += "<";
                     var count = 0;
                     foreach (var genericArgument in clrType.GetDnxCompatible().GetGenericArguments())
                     {


### PR DESCRIPTION
For example, on the first run with a generic type, say `Foo<Bar>`, `GetFullName(Type)` would return ``Fully.Qualified.Foo`1``. Subsequent requests would return just `Fully.Qualified.Foo` therefore causing an exception when trying to `String.Remove` the ``IndexOf('`')``.

Fixed by moving the call to add the type to the ModelBuilder, so that `GetFullName(Type)` always returns the type name without the backtick or subsequent text.