### PR TITLE
Resolve complex objects creating URLs containing `[object Object]`

### DIFF
--- a/TypeGap/Resources/AjaxHelpers.ts
+++ b/TypeGap/Resources/AjaxHelpers.ts
@@ -8,8 +8,21 @@
                 throw new Error("Parameter '" + pname + "' is not optional but a value was not provided.");
             return null;
         }
+        if (isRoute) {
+            return data;
+        }
+        if (Array.isArray(data)) {
+            const flattened = data.map(function (item, i) {
+                return _serialize_data(item, pname + "[" + i + "].")
+            });
+            data = flattened.join("&");
+            return data;
+        }
+        if (typeof data === "object") {
+            return _serialize_data(data, pname + ".");
+        }
         data = encodeURIComponent(data);
-        return isRoute ? data : (pname + "=" + data);
+        return pname + "=" + data;
     }
 
     let skippedName: string;
@@ -58,4 +71,18 @@ function _trim_url(part: any): string {
 function _is_real(value: any): boolean {
     // check if a value is real or empty. blank strings considered empty, but zero is not.
     return value !== "" && value !== undefined && value !== null && !(Array.isArray(value) && value.length === 0);
+}
+
+function _serialize_data(obj: any, prefix: string): string {
+    // serialize complex objects into key-value pairs with optional prefix
+    const items = [];
+    for (const p in obj) {
+        if (obj.hasOwnProperty(p)) {
+            var key = prefix ? prefix + p : p;
+            var value = obj[p];
+            const item = (value !== null && typeof value === "object") ? _serialize_data(value, key) : key + "=" + encodeURIComponent(value);
+            items.push(item);
+        }
+    }
+    return items.join("&");
 }


### PR DESCRIPTION
Enabled support for complex objects to be converted into valid query string values rather than `[object Object]`