### PR TITLE
Bugfix for custom converters not executing

### DIFF
--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TsGenerator.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TsGenerator.cs
@@ -129,6 +129,10 @@ namespace TypeLite {
             _typeConvertors.RegisterTypeConverter<TFor>(convertor);
         }
 
+        public bool IsTypeConvertorRegistered(Type typeFor) {
+            return _typeConvertors.IsConvertorRegistered(typeFor);
+        }
+
         /// <summary>
         /// Sets the formatter for class member identifiers.
         /// </summary>

--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TsModels/TsType.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TsModels/TsType.cs
@@ -49,7 +49,7 @@ namespace TypeLite.TsModels {
         /// </summary>
         /// <param name="type">The CLR type to get TsTypeFamily of</param>
         /// <returns>TsTypeFamily of the CLR type</returns>
-        internal static TsTypeFamily GetTypeFamily(System.Type type) {
+        public static TsTypeFamily GetTypeFamily(System.Type type) {
             if (type.IsNullable()) {
                 return TsType.GetTypeFamily(type.GetNullableValueType());
             }

--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TsModels/TsTypeFamily.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TsModels/TsTypeFamily.cs
@@ -7,7 +7,7 @@ namespace TypeLite.TsModels {
 	/// <summary>
 	/// Represents a type of the TsType
 	/// </summary>
-	internal enum TsTypeFamily {
+	public enum TsTypeFamily {
 		/// <summary>
 		/// System type
 		/// </summary>

--- a/LukasKabrt-typelite-076249af9d12/TypeLite/TypeScript.cs
+++ b/LukasKabrt-typelite-076249af9d12/TypeLite/TypeScript.cs
@@ -256,6 +256,10 @@ namespace TypeLite {
 			return this;
 		}
 
+		public bool IsTypeConvertorRegistered(Type typeFor) {
+			return _scriptGenerator.IsTypeConvertorRegistered(typeFor);
+		}
+
         /// <summary>
         /// Registers a model visitor which will trigger for each entity added to the model
         /// </summary>

--- a/TypeGap/TypeFluent.cs
+++ b/TypeGap/TypeFluent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -183,8 +183,14 @@ namespace TypeGap
                 if (clrTypeToUse.GetDnxCompatible().GetCustomAttribute(typeof(CompilerGeneratedAttribute)) != null)
                     continue;
 
-                if (clrTypeToUse.Namespace.StartsWith("System"))
+                // No need to add types which TypeLite considers built-in
+                if (TsType.GetTypeFamily(clrTypeToUse) == TsTypeFamily.System)
                     continue;
+
+                // Skip all other System types unless a custom converter is registered for it
+                if (clrTypeToUse.Namespace.StartsWith("System"))
+                    if (!generator.IsTypeConvertorRegistered(clrTypeToUse))
+                        continue;
 
                 if (clrTypeToUse.IsIDictionary())
                     continue;


### PR DESCRIPTION
Type converters only run for types which have been added to the model builder, or TypeLite considers built-in. TypeFluent's ProcessTypes skips all system types. Hence the example below doesn't even run the Guid to string converter which is built-in to TypeGap.

The reason why Guid conversions work in some projects is because the first time a Guid is encountered, it is not by TypeGap, but rather by TypeLite, which adds it to the model.

```
    class Program
    {
        static void Main(string[] args)
        {
            var builder = new TypeFluent();
            builder.Add(typeof(Foo));
            Console.WriteLine(builder.Build());
        }
    }

    class Foo
    {
        public Guid Id { get; set; }
    }
```

Expected output:

```
        interface Foo {
            Id: string;
        }
```

Actual output before this fix:


```
        interface Foo {
            Id: any;
        }
```
